### PR TITLE
Reverse the order of structures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 poc/poc
 .vagrant
 *.sw[op]
+*.asm

--- a/poc/Makefile
+++ b/poc/Makefile
@@ -5,4 +5,5 @@ RAND-SEED := 0
 RAND-SEED-SCRIPT:=$(shell python ../rand-seed.py $(RAND-SEED))
 
 all:
-	clang -Xclang -load -Xclang $(PLUGIN) -Xclang -add-plugin -Xclang randstruct -Xclang -plugin-arg-randstruct -Xclang $(RAND-SEED-SCRIPT) poc.c -o poc
+	clang -Xclang -load -Xclang $(PLUGIN) -Xclang -add-plugin -Xclang randstruct -Xclang -plugin-arg-randstruct -Xclang $(RAND-SEED-SCRIPT) -g poc.c -o poc
+	objdump -SD poc > poc.asm

--- a/poc/poc.c
+++ b/poc/poc.c
@@ -1,13 +1,35 @@
+#include <stddef.h>
 #include <stdio.h>
 
 struct mystruct {
-	int *p;
-	int *c;
+  char *first;
+  char *second;
 };
 
-int main(void)
-{
-	struct mystruct m = { 0, 0 };
-	puts("Proof of Concept!");
-	return 0;
+struct ints {
+  int a;
+  int b;
+};
+
+int main(void) {
+  char *first = "I'm the first string!";
+  char *second = "And I'm the second string!";
+  const char *FMT = "%s\n%s\n";
+  struct mystruct m;
+  m.first = first;
+  m.second = second;
+
+  // There shouldn't be any padding for this structure here,
+  // so it should be the width of two (char*) pointers == 16 bytes
+  //
+  // Assuming the fields were REVERSED, then the field located
+  // at the structure's address should be technically the 2nd field
+  // and the last field should be what used to be the FIRST field.
+  printf(FMT, *(&m), *(&m + sizeof(char *)));
+
+  struct ints i;
+  i.a = 100;
+  i.b = 999;
+  printf("%d\n%d\n", *((int *)&i), *((int *)&i + 1));
+  return 0;
 }

--- a/src/randstruct.cpp
+++ b/src/randstruct.cpp
@@ -1,73 +1,70 @@
-//===- Randstruct.cpp ---------------------------------------------===//
-//
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
-//
-//===----------------------------------------------------------------------===//
+#include <stack>
 
-#include "clang/Frontend/FrontendPluginRegistry.h"
 #include "clang/AST/AST.h"
 #include "clang/AST/ASTConsumer.h"
+#include "clang/AST/ExternalASTSource.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
 #include "clang/Sema/Sema.h"
-#include "clang/AST/ExternalASTSource.h"
 #include "llvm/Support/raw_ostream.h"
 using namespace clang;
 
 namespace {
 
 class Randstruct : public ExternalASTSource {
-  virtual bool layoutRecordType(const RecordDecl *Record, 
-                                uint64_t &Size, 
-                                uint64_t &Alignment, 
-                                llvm::DenseMap<const FieldDecl *, uint64_t> &FieldOffsets, 
-                                llvm::DenseMap<const CXXRecordDecl *, CharUnits> &BaseOffsets, 
-                                llvm::DenseMap<const CXXRecordDecl *, CharUnits> &VirtualBaseOffsets) override {
-                                  llvm::errs() << "randstruct is responsible for this structure's layout!\n";
-                                  return false;
-                                }
+public:
+  Randstruct(CompilerInstance &I) : Instance(I) {}
+  CompilerInstance &Instance;
+
+  virtual bool layoutRecordType(
+      const RecordDecl *Record, uint64_t &Size, uint64_t &Alignment,
+      llvm::DenseMap<const FieldDecl *, uint64_t> &FieldOffsets,
+      llvm::DenseMap<const CXXRecordDecl *, CharUnits> &BaseOffsets,
+      llvm::DenseMap<const CXXRecordDecl *, CharUnits> &VirtualBaseOffsets)
+      override {
+    auto &ctx = Instance.getASTContext();
+    Size = 0;
+
+    std::stack<FieldDecl *> fields;
+    for (auto field : Record->fields()) {
+      fields.push(field);
+    }
+
+    while (!fields.empty()) {
+      auto f = fields.top();
+      fields.pop();
+
+      auto width = ctx.getTypeInfo(f->getType()).Width;
+      auto align = ctx.getTypeInfo(f->getType()).Align;
+      Alignment = Alignment > align ? Alignment : align;
+
+      // llvm::errs() << "offset " <<  Size << ":\t" << f->getNameAsString() <<
+      // "\t(" << width << " bits)\n";
+      FieldOffsets[f] = Size;
+      Size += width;
+    }
+
+    // llvm::errs() << "Size: " << Size << " (" << Size / 8 << " bytes)\n";
+    return true;
+  }
 };
 
 class RandstructConsumer : public ASTConsumer {
   CompilerInstance &Instance;
-  std::set<std::string> ParsedTemplates;
 
 public:
-  RandstructConsumer(CompilerInstance &Instance,
-                         std::set<std::string> ParsedTemplates)
-      : Instance(Instance), ParsedTemplates(ParsedTemplates) {
-        Instance.getASTContext().setExternalSource(llvm::IntrusiveRefCntPtr<Randstruct>(new Randstruct));
-        // auto& ctx = Instance.getASTContext();
-        // ctx.setExternalSource( ... )
-        //                         ^ an instance of our implementation of ExternalASTSource goes here!
-      }
-
-  bool HandleTopLevelDecl(DeclGroupRef DG) override {
-    /*
-    for (DeclGroupRef::iterator i = DG.begin(), e = DG.end(); i != e; ++i) {
-      const Decl *D = *i;
-      if (const RecordDecl *RD = dyn_cast<RecordDecl>(D)) {
-        llvm::errs() << "record-decl: \"" << RD->getNameAsString() << "\"\n";
-        for (auto field : RD->fields())
-          llvm::errs() << "\tfield: \"" << field->getNameAsString() << "\" " << "(" << field->getType().getAsString() << ")" << "\n";
-      }
-    }
-    */
-
-    return true;
+  RandstructConsumer(CompilerInstance &Instance) : Instance(Instance) {
+    Instance.getASTContext().setExternalSource(
+        llvm::IntrusiveRefCntPtr<Randstruct>(new Randstruct(Instance)));
   }
-
 };
 
 class RandstructAction : public PluginASTAction {
-  std::set<std::string> ParsedTemplates;
 protected:
   std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI,
                                                  llvm::StringRef) override {
-    return llvm::make_unique<RandstructConsumer>(CI, ParsedTemplates);
+    return llvm::make_unique<RandstructConsumer>(CI);
   }
 
   bool ParseArgs(const CompilerInstance &CI,
@@ -89,7 +86,6 @@ protected:
           return false;
         }
         ++i;
-        ParsedTemplates.insert(args[i]);
       }
     }
     if (!args.empty() && args[0] == "help")
@@ -97,13 +93,12 @@ protected:
 
     return true;
   }
-  void PrintHelp(llvm::raw_ostream& ros) {
+  void PrintHelp(llvm::raw_ostream &ros) {
     ros << "Help for Randstruct plugin goes here\n";
   }
-
 };
 
-}
+} // namespace
 
 static FrontendPluginRegistry::Add<RandstructAction>
-X("randstruct", "randomizes the layout of structures");
+    X("randstruct", "randomizes the layout of structures");


### PR DESCRIPTION
Our first step of many towards randomizing structures!

This PR shows our plugin reversing the order of simple homogeneous C structures.

I ran this through `clang-format` as well.