### PR TITLE
Add padding/alignment aware offsetting

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,3 @@
 find_package(Clang REQUIRED)
-add_library(randstruct SHARED randstruct.cpp)
+add_library(randstruct SHARED plugin.cpp randstruct.cpp)
 target_include_directories(randstruct PUBLIC ${CLANG_INCLUDE_DIRS})

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -1,0 +1,64 @@
+#include <stack>
+
+#include "clang/AST/AST.h"
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Sema/Sema.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "randstruct.h"
+
+namespace {
+class RandstructConsumer : public ASTConsumer {
+  CompilerInstance &Instance;
+
+public:
+  RandstructConsumer(CompilerInstance &Instance) : Instance(Instance) {
+    Instance.getASTContext().setExternalSource(
+        llvm::IntrusiveRefCntPtr<Randstruct>(new Randstruct(Instance)));
+  }
+};
+
+class RandstructAction : public PluginASTAction {
+protected:
+  std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI,
+                                                 llvm::StringRef) override {
+    return llvm::make_unique<RandstructConsumer>(CI);
+  }
+
+  bool ParseArgs(const CompilerInstance &CI,
+                 const std::vector<std::string> &args) override {
+    for (unsigned i = 0, e = args.size(); i != e; ++i) {
+      llvm::errs() << "Randstruct arg = " << args[i] << "\n";
+
+      // Example error handling.
+      DiagnosticsEngine &D = CI.getDiagnostics();
+      if (args[i] == "-an-error") {
+        unsigned DiagID = D.getCustomDiagID(DiagnosticsEngine::Error,
+                                            "invalid argument '%0'");
+        D.Report(DiagID) << args[i];
+        return false;
+      } else if (args[i] == "-parse-template") {
+        if (i + 1 >= e) {
+          D.Report(D.getCustomDiagID(DiagnosticsEngine::Error,
+                                     "missing -parse-template argument"));
+          return false;
+        }
+        ++i;
+      }
+    }
+    if (!args.empty() && args[0] == "help")
+      PrintHelp(llvm::errs());
+
+    return true;
+  }
+  void PrintHelp(llvm::raw_ostream &ros) {
+    ros << "Help for Randstruct plugin goes here\n";
+  }
+};
+
+} // namespace
+
+static FrontendPluginRegistry::Add<RandstructAction>
+    X("randstruct", "randomizes the layout of structures");

--- a/src/randstruct.cpp
+++ b/src/randstruct.cpp
@@ -24,6 +24,7 @@ public:
       llvm::DenseMap<const CXXRecordDecl *, CharUnits> &VirtualBaseOffsets)
       override {
     auto &ctx = Instance.getASTContext();
+    Alignment = 0;
     Size = 0;
 
     std::stack<FieldDecl *> fields;

--- a/src/randstruct.cpp
+++ b/src/randstruct.cpp
@@ -1,130 +1,92 @@
 #include <stack>
+#include <vector>
 
 #include "clang/AST/AST.h"
-#include "clang/AST/ASTConsumer.h"
-#include "clang/AST/ExternalASTSource.h"
-#include "clang/AST/RecursiveASTVisitor.h"
-#include "clang/Frontend/CompilerInstance.h"
-#include "clang/Frontend/FrontendPluginRegistry.h"
-#include "clang/Sema/Sema.h"
 #include "llvm/Support/raw_ostream.h"
-using namespace clang;
 
-namespace {
+#include "randstruct.h"
 
-class Randstruct : public ExternalASTSource {
-public:
-  Randstruct(CompilerInstance &I) : Instance(I) {}
-  CompilerInstance &Instance;
+// TODO Implement Randomization algorithm. Currently only
+// reversing the fields.
+static std::vector<FieldDecl *> rearrange(std::vector<FieldDecl *> fields) {
+  std::stack<FieldDecl *> forReversal;
+  std::vector<FieldDecl *> newOrder;
 
-  virtual bool layoutRecordType(
-      const RecordDecl *Record, uint64_t &Size, uint64_t &Alignment,
-      llvm::DenseMap<const FieldDecl *, uint64_t> &FieldOffsets,
-      llvm::DenseMap<const CXXRecordDecl *, CharUnits> &BaseOffsets,
-      llvm::DenseMap<const CXXRecordDecl *, CharUnits> &VirtualBaseOffsets)
-      override {
-    auto &ctx = Instance.getASTContext();
-    Alignment = 0;
-    Size = 0;
+  for (auto field : fields)
+    forReversal.push(field);
+  while (!forReversal.empty()) {
+    newOrder.push_back(forReversal.top());
+    forReversal.pop();
+  }
 
-    std::stack<FieldDecl *> fields;
-    for (auto field : Record->fields()) {
-      fields.push(field);
-    }
+  return newOrder;
+}
 
-    #ifndef NDEBUG
-    llvm::errs() << "Type\tSize\tAlign\tOffset\tAligned?\n"
-                 << "----\t----\t-----\t------\t--------\n";
-    #endif
+static bool layout(std::vector<FieldDecl *> &fields, ASTContext &ctx,
+                   uint64_t &Size, uint64_t &Alignment,
+                   llvm::DenseMap<const FieldDecl *, uint64_t> &FieldOffsets) {
+  Alignment = 0;
+  Size = 0;
 
-    while (!fields.empty()) {
-      auto f = fields.top();
-      fields.pop();
+#ifndef NDEBUG
+  llvm::errs() << "Type\tSize\tAlign\tOffset\tAligned?\n"
+               << "----\t----\t-----\t------\t--------\n";
+#endif
 
-      auto width = ctx.getTypeInfo(f->getType()).Width;
-      auto align = ctx.getTypeInfo(f->getType()).Align;
-      Alignment = Alignment > align ? Alignment : align;
-
-      // https://en.wikipedia.org/wiki/Data_structure_alignment#Computing_padding
-      auto padding = (-Size & (align - 1));
-
-      FieldOffsets[f] = Size + padding;
-
-      #ifndef NDEBUG
-      llvm::errs() << f->getType().getAsString() << "\t"
-                   << width << "\t" << align << "\t" << Size + padding << "\t"
-                   << ((Size + width + padding) % align == 0 ? "Yes" : "No") << "\n";
-      #endif
-
-      Size += width + padding;
-    }
+  for (auto f : fields) {
+    auto width = ctx.getTypeInfo(f->getType()).Width;
+    auto align = ctx.getTypeInfo(f->getType()).Align;
+    Alignment = Alignment > align ? Alignment : align;
 
     // https://en.wikipedia.org/wiki/Data_structure_alignment#Computing_padding
-    auto tailpadded = (Size + (Alignment - 1)) & -Alignment;
+    auto padding = (-Size & (align - 1));
 
-    Size = tailpadded;
+    FieldOffsets[f] = Size + padding;
 
-    #ifndef NDEBUG
-    llvm::errs() << "\n"
-                 << "Structure Size: " << Size << " bits ("
-                 << "Should be " << Size + (Alignment - (Size % Alignment)) % Alignment << " bits)\n"
-                 << "Alignment: " << Alignment << " bits\n"
+#ifndef NDEBUG
+    llvm::errs() << f->getType().getAsString() << "\t" << width << "\t" << align
+                 << "\t" << Size + padding << "\t"
+                 << ((Size + width + padding) % align == 0 ? "Yes" : "No")
                  << "\n";
-    #endif
+#endif
 
-    return true;
-  }
-};
-
-class RandstructConsumer : public ASTConsumer {
-  CompilerInstance &Instance;
-
-public:
-  RandstructConsumer(CompilerInstance &Instance) : Instance(Instance) {
-    Instance.getASTContext().setExternalSource(
-        llvm::IntrusiveRefCntPtr<Randstruct>(new Randstruct(Instance)));
-  }
-};
-
-class RandstructAction : public PluginASTAction {
-protected:
-  std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI,
-                                                 llvm::StringRef) override {
-    return llvm::make_unique<RandstructConsumer>(CI);
+    Size += width + padding;
   }
 
-  bool ParseArgs(const CompilerInstance &CI,
-                 const std::vector<std::string> &args) override {
-    for (unsigned i = 0, e = args.size(); i != e; ++i) {
-      llvm::errs() << "Randstruct arg = " << args[i] << "\n";
+  // https://en.wikipedia.org/wiki/Data_structure_alignment#Computing_padding
+  auto tailpadded = (Size + (Alignment - 1)) & -Alignment;
 
-      // Example error handling.
-      DiagnosticsEngine &D = CI.getDiagnostics();
-      if (args[i] == "-an-error") {
-        unsigned DiagID = D.getCustomDiagID(DiagnosticsEngine::Error,
-                                            "invalid argument '%0'");
-        D.Report(DiagID) << args[i];
-        return false;
-      } else if (args[i] == "-parse-template") {
-        if (i + 1 >= e) {
-          D.Report(D.getCustomDiagID(DiagnosticsEngine::Error,
-                                     "missing -parse-template argument"));
-          return false;
-        }
-        ++i;
-      }
-    }
-    if (!args.empty() && args[0] == "help")
-      PrintHelp(llvm::errs());
+  Size = tailpadded;
 
-    return true;
+#ifndef NDEBUG
+  llvm::errs() << "\n"
+               << "Structure Size: " << Size << " bits ("
+               << "Should be "
+               << Size + (Alignment - (Size % Alignment)) % Alignment
+               << " bits)\n"
+               << "Alignment: " << Alignment << " bits\n"
+               << "\n";
+#endif
+
+  return true;
+}
+
+bool Randstruct::layoutRecordType(
+    const RecordDecl *Record, uint64_t &Size, uint64_t &Alignment,
+    llvm::DenseMap<const FieldDecl *, uint64_t> &FieldOffsets,
+    llvm::DenseMap<const CXXRecordDecl *, CharUnits> &BaseOffsets,
+    llvm::DenseMap<const CXXRecordDecl *, CharUnits> &VirtualBaseOffsets) {
+  auto &ctx = Instance.getASTContext();
+  Alignment = 0;
+  Size = 0;
+
+  std::vector<FieldDecl *> fields;
+  for (auto field : Record->fields()) {
+    fields.push_back(field);
   }
-  void PrintHelp(llvm::raw_ostream &ros) {
-    ros << "Help for Randstruct plugin goes here\n";
-  }
-};
 
-} // namespace
+  fields = rearrange(fields);
 
-static FrontendPluginRegistry::Add<RandstructAction>
-    X("randstruct", "randomizes the layout of structures");
+  return layout(fields, Instance.getASTContext(), Size, Alignment,
+                FieldOffsets);
+}

--- a/src/randstruct.cpp
+++ b/src/randstruct.cpp
@@ -59,7 +59,7 @@ public:
       Size += width + padding;
     }
 
-    // TODO fixme: tail padding is needed for some structures
+    Size += (Alignment - (Size % Alignment)) % Alignment;
 
     #ifndef NDEBUG
     llvm::errs() << "\n"

--- a/src/randstruct.cpp
+++ b/src/randstruct.cpp
@@ -59,6 +59,8 @@ public:
       Size += width + padding;
     }
 
+    // TODO fixme: tail padding is needed for some structures
+
     #ifndef NDEBUG
     llvm::errs() << "\n"
                  << "Structure Size: " << Size << " bits ("

--- a/src/randstruct.cpp
+++ b/src/randstruct.cpp
@@ -59,7 +59,10 @@ public:
       Size += width + padding;
     }
 
-    Size += (Alignment - (Size % Alignment)) % Alignment;
+    // https://en.wikipedia.org/wiki/Data_structure_alignment#Computing_padding
+    auto tailpadded = (Size + (Alignment - 1)) & -Alignment;
+
+    Size = tailpadded;
 
     #ifndef NDEBUG
     llvm::errs() << "\n"

--- a/src/randstruct.h
+++ b/src/randstruct.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "clang/AST/ExternalASTSource.h"
+#include "clang/Frontend/CompilerInstance.h"
+
+using namespace clang;
+
+class Randstruct : public ExternalASTSource {
+private:
+  CompilerInstance &Instance;
+
+public:
+  Randstruct(CompilerInstance &I) : Instance(I) {}
+
+  virtual bool layoutRecordType(
+      const RecordDecl *Record, uint64_t &Size, uint64_t &Alignment,
+      llvm::DenseMap<const FieldDecl *, uint64_t> &FieldOffsets,
+      llvm::DenseMap<const CXXRecordDecl *, CharUnits> &BaseOffsets,
+      llvm::DenseMap<const CXXRecordDecl *, CharUnits> &VirtualBaseOffsets)
+      override;
+};


### PR DESCRIPTION
This PR brings us one-step closer to remaining regression-free from out-of-the-box compiler structure layouts.

~Note, we still need to find a way to properly insert tail-padding. More notes here: https://github.com/connorkuehl/clang_randstruct/issues/49#issuecomment-454992314~

Note: the `#ifndef NDEBUG` is a CMake preprocessor define that is defined when you build a `Release` build. If your CMake doesn't output the print statements that are enclosed in these, try to regenerate your Makefile with `cmake -DCMAKE_BUILD_TYPE=Debug ..` in your `build` directory.