### PR TITLE
Respect alignment compiler directives

### DIFF
--- a/src/randstruct.cpp
+++ b/src/randstruct.cpp
@@ -16,9 +16,10 @@ static std::vector<FieldDecl *> rearrange(std::vector<FieldDecl *> fields) {
   return fields;
 }
 
-static bool layout(std::vector<FieldDecl *> &fields, ASTContext &ctx,
+static bool layout(const RecordDecl *Record, std::vector<FieldDecl *> &fields,
                    uint64_t &Size, uint64_t &Alignment,
-                   llvm::DenseMap<const FieldDecl *, uint64_t> &FieldOffsets) {
+                   llvm::DenseMap<const FieldDecl *, uint64_t> &FieldOffsets,
+                   ASTContext &ctx) {
   Alignment = 0;
   Size = 0;
 
@@ -30,6 +31,7 @@ static bool layout(std::vector<FieldDecl *> &fields, ASTContext &ctx,
   for (auto f : fields) {
     auto width = ctx.getTypeInfo(f->getType()).Width;
     auto align = ctx.getTypeInfo(f->getType()).Align;
+
     Alignment = Alignment > align ? Alignment : align;
 
     // https://en.wikipedia.org/wiki/Data_structure_alignment#Computing_padding
@@ -82,6 +84,6 @@ bool Randstruct::layoutRecordType(
 
   fields = rearrange(fields);
 
-  return layout(fields, Instance.getASTContext(), Size, Alignment,
-                FieldOffsets);
+  return layout(Record, fields, Size, Alignment,
+                FieldOffsets, Instance.getASTContext());
 }

--- a/src/randstruct.cpp
+++ b/src/randstruct.cpp
@@ -55,6 +55,12 @@ static bool layout(const RecordDecl *Record, std::vector<FieldDecl *> &fields,
 
   Size = tailpadded;
 
+  // Respect the programmer's requested alignment from the structure
+  // by overriding what we've calculated so far.
+  if (auto alignAttr = Record->getAttr<AlignedAttr>()) {
+      Alignment = alignAttr->getAlignment(ctx);
+  }
+
 #ifndef NDEBUG
   llvm::errs() << "\n"
                << "Structure Size: " << Size << " bits ("

--- a/src/randstruct.cpp
+++ b/src/randstruct.cpp
@@ -7,10 +7,7 @@
 
 #include "randstruct.h"
 
-// TODO Implement Randomization algorithm. Currently only
-// reversing the fields.
 static std::vector<FieldDecl *> rearrange(std::vector<FieldDecl *> fields) {
-
   auto rng = std::default_random_engine{};
   std::shuffle(std::begin(fields), std::end(fields), rng);
   return fields;
@@ -58,7 +55,7 @@ static bool layout(const RecordDecl *Record, std::vector<FieldDecl *> &fields,
   // Respect the programmer's requested alignment from the structure
   // by overriding what we've calculated so far.
   if (auto alignAttr = Record->getAttr<AlignedAttr>()) {
-      Alignment = alignAttr->getAlignment(ctx);
+    Alignment = alignAttr->getAlignment(ctx);
   }
 
 #ifndef NDEBUG
@@ -90,6 +87,6 @@ bool Randstruct::layoutRecordType(
 
   fields = rearrange(fields);
 
-  return layout(Record, fields, Size, Alignment,
-                FieldOffsets, Instance.getASTContext());
+  return layout(Record, fields, Size, Alignment, FieldOffsets,
+                Instance.getASTContext());
 }


### PR DESCRIPTION
Closes #74.

There are common compiler directives such as `alignas` or `__attribute((align))__` that allow program writers to specify what they want the field or structure aligned to. Our plugin should also respect that.

For example:

```c
struct mystruct {
  char *first;
  char *second;
} __attribute__((__aligned__(2)));;
```

Results in:

```
Name	Type	Size	Align	Offset	Aligned?
----	----	-----	------	--------
second	char *	64	64	0	Yes
first	char *	64	64	64	Yes

Structure Size: 128 bits (Should be 128 bits)
Alignment: 16 bits // <------------
```

Instead of:

```
Name	Type	Size	Align	Offset	Aligned?
----	----	-----	------	--------
second	char *	64	64	0	Yes
first	char *	64	64	64	Yes

Structure Size: 128 bits (Should be 128 bits)
Alignment: 64 bits // <------------
```