### PR TITLE
Add initial implementation of performance sensitive randomization

### DIFF
--- a/poc/poc.c
+++ b/poc/poc.c
@@ -11,6 +11,18 @@ struct ints {
   int b;
 };
 
+struct perf {
+	int a;
+	long tim;
+	unsigned b : 1;
+	unsigned c : 1;
+	short d;
+	char e;
+	long james;
+	double cole;
+	long jordan;
+};
+
 int main(void) {
   char *first = "I'm the first string!";
   char *second = "And I'm the second string!";
@@ -18,6 +30,8 @@ int main(void) {
   struct mystruct m;
   m.first = first;
   m.second = second;
+
+  struct perf p;
 
   // There shouldn't be any padding for this structure here,
   // so it should be the width of two (char*) pointers == 16 bytes

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(randstruct SHARED plugin.cpp randstruct.cpp)
+add_library(randstruct SHARED plugin.cpp randstruct.cpp bucket.cpp)
 target_include_directories(randstruct PUBLIC ${CLANG_INCLUDE_DIRS})
 target_compile_definitions(randstruct PUBLIC ${CLANG_DEFINITIONS})
 #target_compile_options(randstruct PUBLIC -fno-exceptions -fno-rtti)

--- a/src/bucket.cpp
+++ b/src/bucket.cpp
@@ -1,0 +1,24 @@
+#include "bucket.h"
+
+const size_t CACHE_LINE = 64;
+
+std::vector<FieldDecl *> Bucket::randomize() {
+    // TODO
+    return fields;
+}
+
+bool Bucket::canFit(size_t size) const {
+    return this->size + size <= CACHE_LINE;
+}
+
+void Bucket::add(FieldDecl *field) {
+    fields.push_back(field);
+}
+
+std::vector<FieldDecl *> BitfieldRun::randomize() {
+    return fields;
+}
+
+bool BitfieldRun::canFit(size_t size) const {
+    return true;
+}

--- a/src/bucket.cpp
+++ b/src/bucket.cpp
@@ -1,9 +1,14 @@
+#include <algorithm>
+#include <random>
+
 #include "bucket.h"
 
 const size_t CACHE_LINE = 64;
 
 std::vector<FieldDecl *> Bucket::randomize() {
-    // TODO
+    // TODO use seed
+    auto rng = std::default_random_engine{};
+    std::shuffle(std::begin(fields), std::end(fields), rng);
     return fields;
 }
 
@@ -11,8 +16,17 @@ bool Bucket::canFit(size_t size) const {
     return this->size + size <= CACHE_LINE;
 }
 
-void Bucket::add(FieldDecl *field) {
+void Bucket::add(FieldDecl *field, size_t size) {
     fields.push_back(field);
+    this->size += size;
+}
+
+bool Bucket::isBitfieldRun() const {
+    return false;
+}
+
+bool Bucket::full() const {
+    return size == CACHE_LINE;
 }
 
 std::vector<FieldDecl *> BitfieldRun::randomize() {
@@ -20,5 +34,9 @@ std::vector<FieldDecl *> BitfieldRun::randomize() {
 }
 
 bool BitfieldRun::canFit(size_t size) const {
+    return true;
+}
+
+bool BitfieldRun::isBitfieldRun() const {
     return true;
 }

--- a/src/bucket.cpp
+++ b/src/bucket.cpp
@@ -3,6 +3,7 @@
 
 #include "bucket.h"
 
+// TODO: Is there a way to detect this? (i.e. on 32bit system vs 64?)
 const size_t CACHE_LINE = 64;
 
 std::vector<FieldDecl *> Bucket::randomize() {
@@ -13,6 +14,7 @@ std::vector<FieldDecl *> Bucket::randomize() {
 }
 
 bool Bucket::canFit(size_t size) const {
+    // A bucket can only fill up to a cache line.
     return this->size + size <= CACHE_LINE;
 }
 
@@ -22,21 +24,26 @@ void Bucket::add(FieldDecl *field, size_t size) {
 }
 
 bool Bucket::isBitfieldRun() const {
+    // The normal bucket is not a bitfieldrun. This is to avoid RTTI.
     return false;
 }
 
 bool Bucket::full() const {
+    // We're full if our size is a cache line.
     return size == CACHE_LINE;
 }
 
 std::vector<FieldDecl *> BitfieldRun::randomize() {
+    // Keep bit fields adjacent, we will not scramble them.
     return fields;
 }
 
 bool BitfieldRun::canFit(size_t size) const {
+    // We can always fit another adjacent bitfield.
     return true;
 }
 
 bool BitfieldRun::isBitfieldRun() const {
+    // Yes.
     return true;
 }

--- a/src/bucket.h
+++ b/src/bucket.h
@@ -11,7 +11,9 @@ class Bucket {
     public:
         virtual std::vector<FieldDecl *> randomize();
         virtual bool canFit(size_t size) const;
-        void add(FieldDecl *field);
+        void add(FieldDecl *field, size_t size);
+        virtual bool isBitfieldRun() const;
+        bool full() const;
 
     protected:
         size_t size;
@@ -22,4 +24,5 @@ class BitfieldRun : public Bucket {
     public:
         virtual std::vector<FieldDecl *> randomize() override;
         virtual bool canFit(size_t size) const override;
+        virtual bool isBitfieldRun() const override;
 };

--- a/src/bucket.h
+++ b/src/bucket.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "clang/AST/AST.h"
+
+using namespace clang;
+
+class Bucket {
+    public:
+        virtual std::vector<FieldDecl *> randomize();
+        virtual bool canFit(size_t size) const;
+        void add(FieldDecl *field);
+
+    protected:
+        size_t size;
+        std::vector<FieldDecl *> fields;
+};
+
+class BitfieldRun : public Bucket {
+    public:
+        virtual std::vector<FieldDecl *> randomize() override;
+        virtual bool canFit(size_t size) const override;
+};

--- a/src/bucket.h
+++ b/src/bucket.h
@@ -7,12 +7,18 @@
 
 using namespace clang;
 
+/// Bucket to store fields up to size of a cache line during randomization.
 class Bucket {
     public:
+        /// Returns a randomized version of the bucket.
         virtual std::vector<FieldDecl *> randomize();
+        /// Checks if an added element would fit in a cache line.
         virtual bool canFit(size_t size) const;
+        /// Adds a field to the bucket.
         void add(FieldDecl *field, size_t size);
+        /// Is this bucket for bitfields?
         virtual bool isBitfieldRun() const;
+        /// Is this bucket full?
         bool full() const;
 
     protected:
@@ -20,6 +26,8 @@ class Bucket {
         std::vector<FieldDecl *> fields;
 };
 
+/// BitfieldRun is a bucket for storing adjacent bitfields that may
+/// exceed the size of a cache line.
 class BitfieldRun : public Bucket {
     public:
         virtual std::vector<FieldDecl *> randomize() override;

--- a/src/randstruct.cpp
+++ b/src/randstruct.cpp
@@ -28,7 +28,6 @@ std::vector<FieldDecl *> Randstruct::perfrandomize(std::vector<FieldDecl *> fiel
         if (skipped > fields.size()) {
             skipped = 0;
             buckets.push_back(std::move(currentBucket));
-            currentBucket = nullptr;
         }
         auto field = fields.begin();
 
@@ -42,7 +41,6 @@ std::vector<FieldDecl *> Randstruct::perfrandomize(std::vector<FieldDecl *> fiel
         } else {
             if (currentBitfieldRun) {
                 buckets.push_back(std::move(currentBitfieldRun));
-                currentBitfieldRun = nullptr;
             }
             if (!currentBucket) {
                 currentBucket = std::make_unique<Bucket>();
@@ -56,8 +54,6 @@ std::vector<FieldDecl *> Randstruct::perfrandomize(std::vector<FieldDecl *> fiel
                 if (currentBucket->full()) {
                     skipped = 0;
                     buckets.push_back(std::move(currentBucket));
-                    // TODO verify we need this:
-                    currentBucket = nullptr;
                 }
             } else {
                 // Move to the end for processing later
@@ -70,13 +66,10 @@ std::vector<FieldDecl *> Randstruct::perfrandomize(std::vector<FieldDecl *> fiel
 
     if (currentBucket) {
         buckets.push_back(std::move(currentBucket));
-        // TODO verify we need this:
-        currentBucket = nullptr;
     }
 
     if (currentBitfieldRun) {
         buckets.push_back(std::move(currentBitfieldRun));
-        currentBitfieldRun = nullptr;
     }
 
     // TODO use seed

--- a/src/randstruct.cpp
+++ b/src/randstruct.cpp
@@ -7,10 +7,18 @@
 
 #include "randstruct.h"
 
-static std::vector<FieldDecl *> rearrange(std::vector<FieldDecl *> fields) {
+static std::vector<FieldDecl *> randomize(std::vector<FieldDecl *> fields) {
   auto rng = std::default_random_engine{};
   std::shuffle(std::begin(fields), std::end(fields), rng);
   return fields;
+}
+
+static std::vector<FieldDecl *> perfrandomize(std::vector<FieldDecl *> fields) {
+    return fields;
+}
+
+static std::vector<FieldDecl *> rearrange(std::vector<FieldDecl *> fields) {
+    return randomize(fields);
 }
 
 static bool layout(const RecordDecl *Record, std::vector<FieldDecl *> &fields,

--- a/src/randstruct.h
+++ b/src/randstruct.h
@@ -5,13 +5,19 @@
 
 using namespace clang;
 
+/// Randstruct is an ExternalASTSource that provides structure layout functionality.
 class Randstruct : public ExternalASTSource {
 private:
   CompilerInstance &Instance;
 
+  /// Performs basic randomization.
   std::vector<FieldDecl *> randomize(std::vector<FieldDecl *> fields);
+  /// Performs performance-sensitive randomization and makes a best effort
+  /// to group fields into cache lines.
   std::vector<FieldDecl *> perfrandomize(std::vector<FieldDecl *> fields);
+  /// Entry point for reorganizing fields of a structure.
   std::vector<FieldDecl *> rearrange(std::vector<FieldDecl *> fields);
+  /// Performs layout and alignment of a structure.
   bool layout(const RecordDecl *Record, std::vector<FieldDecl *> &fields,
                    uint64_t &Size, uint64_t &Alignment,
                    llvm::DenseMap<const FieldDecl *, uint64_t> &FieldOffsets,
@@ -19,6 +25,7 @@ private:
 public:
   Randstruct(CompilerInstance &I) : Instance(I) {}
 
+  /// Entry point for Randstruct, called by the Clang compiler.
   virtual bool layoutRecordType(
       const RecordDecl *Record, uint64_t &Size, uint64_t &Alignment,
       llvm::DenseMap<const FieldDecl *, uint64_t> &FieldOffsets,

--- a/src/randstruct.h
+++ b/src/randstruct.h
@@ -9,6 +9,13 @@ class Randstruct : public ExternalASTSource {
 private:
   CompilerInstance &Instance;
 
+  std::vector<FieldDecl *> randomize(std::vector<FieldDecl *> fields);
+  std::vector<FieldDecl *> perfrandomize(std::vector<FieldDecl *> fields);
+  std::vector<FieldDecl *> rearrange(std::vector<FieldDecl *> fields);
+  bool layout(const RecordDecl *Record, std::vector<FieldDecl *> &fields,
+                   uint64_t &Size, uint64_t &Alignment,
+                   llvm::DenseMap<const FieldDecl *, uint64_t> &FieldOffsets,
+                   ASTContext &ctx);
 public:
   Randstruct(CompilerInstance &I) : Instance(I) {}
 


### PR DESCRIPTION
This PR contains our initial approach discussed in #83.

These are the constraints:

- Group fields such that they fit into cache lines

- Keep adjacent bitfields together

Here's the abridged approach:

- Try to fill cache-line sized buckets with our fields

- If we can't fit it into a bucket, skip it, and finish processing the rest

- If we can't finish the bucket, tie it off

- If we see a bitfield, create a separate bitfield bucket and keep adding adjacent bitfields to it

- Once done seeing bitfields, tie off the bitfield bucket

- Once processing is finished, we randomize the order of the buckets and build our new layout
